### PR TITLE
Add comprehensive semantic naming for m4a sound engine

### DIFF
--- a/docs/symbol_map.md
+++ b/docs/symbol_map.md
@@ -52,19 +52,105 @@ and added to `[renames]` in `klonoa-eod-decomp.toml`.
 
 ## Sound Engine (m4a)
 
+### Sound System Init & Shutdown
+
 | Address | Proposed Name | Evidence |
 |---------|---------------|----------|
+| FUN_0804eb64 | SoundMain | Main sound system setup; calls stream/gfx init, refs gSoundInfo |
+| FUN_0804ed68 | SoundDmaInit | DMA controller setup for sound; has DMA reg writes |
+| FUN_0804ee34 | SoundReset | Minimal state reset (leaf, 23 lines) |
+| FUN_0804ee60 | DmaControllerInit | Full DMA init; calls SoundReset |
+| FUN_0804ef50 | SoundInfoInit | Initialize SoundInfo struct fields (leaf) |
 | FUN_0804f294 | InitSoundEngine | Called by SoundInit wrapper |
-| FUN_0804ff08 | ResetSoundChannel | Called by StopSoundChannel wrapper |
-| FUN_0804ffc8 | PlayMusicTrack | Called by DispatchMusicStreamCommand, EnableVBlankAndDispatchMusic |
-| FUN_08050648 | SetupVBlankSoundHandler | Called by EnableVBlankHandler, EnableVBlankAndHandlers, InitGraphicsSystem |
-| FUN_08050134 | SetupSoundInterrupt | Called by EnableVBlankAndHandlers |
-| FUN_0805186c | PlaySoundEffect | Called by PlaySoundWithContext_D8/DC, UpdateUIState |
-| FUN_08051870 | DispatchSoundCommand | Called by SoundCommand_6450 |
-| FUN_080507e0 | UpdateSoundChannel | Called by UpdateAllSoundChannels loop |
-| FUN_080506fc | LoadSoundData | Called by PlayMusicTrack |
-| FUN_080505cc | StopAllSound | Called by InitGraphicsSystem, RenderFrame |
-| FUN_080500fc | UpdateAllSoundChannels | Loops 4 times calling UpdateSoundChannel; called by RenderFrame |
+
+### Sound Data & Buffer Management
+
+| Address | Proposed Name | Evidence |
+|---------|---------------|----------|
+| FUN_0804efde | SoundBufferAlloc | Allocate mixing buffers |
+| FUN_0804f004 | SoundContextInit | Setup mixer state; refs gSoundInfo, gStreamPtr, gControlBlock |
+| FUN_0804f0d0 | SoundChannelTableInit | Initialize channel table entries |
+
+### MIDI / Music Sequence Engine
+
+| Address | Proposed Name | Evidence |
+|---------|---------------|----------|
+| FUN_0804f180 | MidiReadUnaligned | Read misaligned MIDI value; calls ReadUnalignedU16 |
+| FUN_0804f1c4 | MidiProcessEvent | Dispatch MIDI note/control event |
+| FUN_0804f248 | MPlayMain | **CORE**: main music player tick (587 lines, largest in m4a, uses DMA) |
+| FUN_0804f6d4 | VoiceUtil | Minimal voice utility (leaf, 22 lines) |
+| FUN_0804f6f4 | VoiceLookup | Voice lookup wrapper |
+| FUN_0804f724 | InstrumentLookup | ROM instrument table lookup (ROM_INSTRUMENT_TABLE) |
+| FUN_0804f73c | InstrumentGetEntry | Get instrument entry from ROM (leaf) |
+| FUN_0804f758 | MidiDecodeByte | Decode single MIDI byte (leaf, 11 lines) |
+| FUN_0804f766 | MidiNoteSetup | Setup MIDI note on channel |
+| FUN_0804f7b4 | MidiCommandHandler | MIDI command dispatch table; writes REG_SOUND1CNT_L |
+| FUN_0804f944 | MPlayContinue | Music playback continuation (327 lines) |
+| FUN_0804fb9c | SoundContextRef | Get sound context reference |
+
+### Music Playback Control
+
+| Address | Proposed Name | Evidence |
+|---------|---------------|----------|
+| FUN_0804fbe0 | MPlayStop_Channel | Stop single music channel (leaf) |
+| FUN_0804fc10 | MPlayStop | Stop all music playback (313 lines) |
+| FUN_0804fe50 | SoundEffectUtil | Sound effect utility (leaf) |
+| FUN_0804fe6c | SoundEffectProcess | Process sound effect chain |
+| FUN_0804fea0 | FreqTableLookup | Frequency lookup from ROM pitch tables |
+| FUN_0804ff08 | MPlayChannelReset | Reset channel state; checks Sappy magic 0x68736D53 |
+| FUN_0804ff44 | m4aSoundInit_Impl | Full sound system init dispatcher |
+| FUN_0804ffc8 | m4aSongNumStart | Start playing music track by ID (ROM_MUSIC_TABLE) |
+| FUN_0804fff6 | m4aSongNumContinue | Continue/queue music track |
+| FUN_08050042 | m4aSongNumLoad | Load music data from ROM |
+| FUN_08050094 | m4aMPlayCommand | Execute music player command |
+| FUN_080500c8 | m4aSongNumStop | Stop current music track |
+| FUN_080500fc | m4aSoundVSync | VBlank: update all sound channels (×4 loop) |
+
+### Sound Hardware & Direct Sound
+
+| Address | Proposed Name | Evidence |
+|---------|---------------|----------|
+| FUN_08050134 | m4aSoundVSyncSetup | Setup VBlank sound sync |
+| FUN_08050162 | SappyStateCheck | Verify Sappy magic marker (0x68736D53) |
+| FUN_080501ba | SoundEffectTrigger | Trigger sound effect via gMPlayInfo_SE |
+| FUN_08050200 | SoundHardwareInit | **CRITICAL**: init all GBA sound regs (14 HW regs: SOUNDCNT, FIFO, DMA) |
+| FUN_08050344 | DirectSoundFifoSetup | **CRITICAL**: FIFO_A/B and DMA config (8 HW regs) |
+| FUN_0805043c | SoundTimerSetup | Configure timer for sample rate |
+| FUN_080504e0 | SoundSystemConfigure | Configure sound system mode |
+| FUN_08050578 | SoundPlatformDetect | Detect platform/capabilities |
+| FUN_080505cc | m4aSoundShutdown | Emergency stop all sound |
+| FUN_08050648 | m4aSoundVSyncOn | Register VBlank sound handler |
+| FUN_08050684 | VBlankSoundCallback | VBlank-triggered sound update |
+| FUN_080506fc | MPlayOpen | Load & open music player data from ROM |
+| FUN_080507e0 | MPlayChannelUpdate | Update single music channel |
+
+### CGB Sound (Channels 1-4) & Pitch Control
+
+| Address | Proposed Name | Evidence |
+|---------|---------------|----------|
+| FUN_08050820 | CgbModVol | CGB channel volume modulation |
+| FUN_080508e8 | CgbLookupTable | CGB frequency/volume lookup data (leaf) |
+| FUN_0805099e | MidiKeyToCgbFreq | MIDI note → CGB frequency; writes 4 pitch regs |
+| FUN_08050a94 | CgbLookupUtil | CGB utility lookup (leaf) |
+| FUN_08050afc | CgbSound | CGB channel hardware control (14 HW regs: SOUND1-4CNT, WAVE_RAM) |
+| FUN_08050c70 | SoundMixerMain | **CORE**: process all mixer channels (393 lines, 2nd largest) |
+
+### Sound State Machine & MIDI Encoding
+
+| Address | Proposed Name | Evidence |
+|---------|---------------|----------|
+| FUN_08050f4a | SoundStateCheck1 | Sappy magic state check (leaf) |
+| FUN_08050f70 | SoundStateCheck2 | Sappy magic state check (leaf) |
+| FUN_08050fd8 | SoundStateCheck3 | Sappy magic state check (leaf) |
+| FUN_0805104c | MidiNoteLookup | MIDI note to frequency lookup (leaf) |
+| FUN_080510b4 | MidiUtilConvert | MIDI utility converter (leaf) |
+| FUN_080510d4 | MidiCommandEncode1 | Encode MIDI command type 1 |
+| FUN_08051148 | MidiCommandEncode2 | Encode MIDI command type 2 |
+| FUN_080511bc | MPlayCommandDispatch | Music command dispatcher (ROM table, 174 lines) |
+| FUN_08051314 | SoundCommandHandler | Command dispatch from ROM_SOUND_CMD_TABLE |
+| FUN_08051348 | BitMaskLUT | 32-bit channel bitmask lookup table (leaf, 118 lines) |
+| FUN_0805186c | PlaySoundEffect | Play sound effect; called by PlaySoundWithContext_D8/DC |
+| FUN_08051870 | DispatchSoundCommand | Dispatch sound command; called by SoundCommand_6450 |
 
 ## System / Utility
 
@@ -88,5 +174,21 @@ and added to `[renames]` in `klonoa-eod-decomp.toml`.
 | 0x080E2A7C | ROM_OAM_TEMPLATE | OAM template data (initial attribute values) |
 | 0x0818B7AC | ROM_GFX_ASSET_TABLE | Graphics asset table for InitGraphicsSystem |
 | 0x0818B8E0 | ROM_TILESET_TABLE | Tileset table for RenderFrame |
-| 0x08118AB4 | ROM_SOUND_DATA_TABLE | Sound/music data table |
 | 0x0800B7B4 | ROM_CHAR_TILE_MAP | Character-to-tile mapping for RenderCharacterTiles |
+
+### Sound ROM Data Tables
+
+| Address | Name | Description |
+|---------|------|-------------|
+| 0x08118AB4 | ROM_MUSIC_TABLE | Music track table: {count, trackDataPtr} entries indexed by track ID |
+| 0x08118AE4 | ROM_MUSIC_META_TABLE | Music track metadata (offsets, lengths, loop points) |
+| 0x08117C8C | ROM_SOUND_CMD_TABLE | Sound command dispatch: function pointer array by command byte |
+| 0x081179E4 | ROM_INSTRUMENT_TABLE | Instrument/voice data: waveform, envelope, pitch per instrument |
+| 0x08117A74 | ROM_FREQ_TABLE_1 | Pitch/frequency lookup table 1 |
+| 0x08117B28 | ROM_FREQ_TABLE_2 | Pitch/frequency lookup table 2 |
+| 0x08117B70 | ROM_PITCH_TABLE | MIDI note-to-pitch conversion table |
+| 0x08117BF4 | ROM_WAVE_DUTY_TABLE | Square wave duty cycle table |
+| 0x08117C0C | ROM_NOISE_TABLE | Noise channel parameter table |
+| 0x08117C48 | ROM_ENVELOPE_TABLE | Volume envelope data |
+| 0x08117C58 | ROM_SWEEP_TABLE | Frequency sweep data |
+| 0x081177E4 | ROM_SOUND_INIT_DATA | Sound configuration init data |

--- a/include/gba.h
+++ b/include/gba.h
@@ -50,12 +50,46 @@
 #define REG_BLDALPHA               (*(vu16 *)0x04000052)
 #define REG_BLDY                   (*(vu16 *)0x04000054)
 
-/* ── Sound Registers ── */
+/* ── Sound Channel 1 (Square with Sweep) ── */
+
+#define REG_SOUND1CNT_L            (*(vu16 *)0x04000060)
+#define REG_SOUND1CNT_H            (*(vu16 *)0x04000062)
+#define REG_SOUND1CNT_X            (*(vu16 *)0x04000064)
+
+/* ── Sound Channel 2 (Square) ── */
+
+#define REG_SOUND2CNT_L            (*(vu16 *)0x04000068)
+#define REG_SOUND2CNT_H            (*(vu16 *)0x0400006C)
+
+/* ── Sound Channel 3 (Wave) ── */
+
+#define REG_SOUND3CNT_L            (*(vu16 *)0x04000070)
+#define REG_SOUND3CNT_H            (*(vu16 *)0x04000072)
+#define REG_SOUND3CNT_X            (*(vu16 *)0x04000074)
+
+/* ── Sound Channel 4 (Noise) ── */
+
+#define REG_SOUND4CNT_L            (*(vu16 *)0x04000078)
+#define REG_SOUND4CNT_H            (*(vu16 *)0x0400007C)
+
+/* ── Master Sound Control ── */
 
 #define REG_SOUNDCNT_L             (*(vu16 *)0x04000080)
 #define REG_SOUNDCNT_H             (*(vu16 *)0x04000082)
 #define REG_SOUNDCNT_X             (*(vu16 *)0x04000084)
 #define REG_SOUNDBIAS              (*(vu16 *)0x04000088)
+
+/* ── Wave RAM ── */
+
+#define REG_WAVE_RAM0              (*(vu32 *)0x04000090)
+#define REG_WAVE_RAM1              (*(vu32 *)0x04000094)
+#define REG_WAVE_RAM2              (*(vu32 *)0x04000098)
+#define REG_WAVE_RAM3              (*(vu32 *)0x0400009C)
+
+/* ── Direct Sound FIFO ── */
+
+#define REG_FIFO_A                 (*(vu32 *)0x040000A0)
+#define REG_FIFO_B                 (*(vu32 *)0x040000A4)
 
 /* ── DMA Registers ── */
 

--- a/include/globals.h
+++ b/include/globals.h
@@ -29,17 +29,29 @@
 /* Buffer freed by FreeBuffer_52A4. */
 #define gBuffer_52A4       (*(u32 *)0x030052A4)
 
-/* ── Sound / Music ── */
+/* ── Sound / Music (m4a / MusicPlayer2000 / Sappy engine) ── */
 
-/* Sound context pointers used by PlaySoundWithContext functions. */
-#define gSoundCtx_D8       (*(u32 *)0x030064D8)
-#define gSoundCtx_DC       (*(u32 *)0x030064DC)
+/* Main sound info struct pointer. Contains channel state, mixer config,
+ * and pointers to the currently playing tracks. */
+#define gSoundInfo         (*(u32 *)0x0300081C)
+
+/* Music player context pointers. Each MusicPlayer instance has its own
+ * context for independent track playback. */
+#define gMPlayInfo_BGM     (*(u32 *)0x030064D8)
+#define gMPlayInfo_SE      (*(u32 *)0x030064DC)
 
 /* Sound command dispatch table pointer. */
 #define gSoundTablePtr     (*(u32 *)0x03006450)
 
-/* Sound struct pointer (for FreeSoundStruct). */
-#define gSoundStructPtr    (*(u32 *)0x0300081C)
+/* Sound command dispatch secondary table pointer. */
+#define gSoundCmdTablePtr  (*(u32 *)0x03006454)
+
+/* Sound engine state/event buffer. */
+#define gSoundEventBuffer  ((u8 *)0x030054A0)
+
+/* Sappy engine magic marker: "Smsh" (0x68736D53) in little-endian.
+ * Used to verify the sound engine is properly initialized. */
+#define SAPPY_MAGIC        0x68736D53
 
 /* ── Game State ── */
 
@@ -134,7 +146,34 @@
 #define ROM_GFX_ASSET_TABLE     0x0818B7AC
 #define ROM_TILESET_TABLE       0x0818B8E0
 
-/* Sound data tables. */
-#define ROM_SOUND_DATA_TABLE    0x08118AB4
+/* ── Sound ROM Data Tables ── */
+
+/* Music track table: array of {u32 count, u32 trackDataPtr} entries.
+ * Indexed by track ID in PlayMusicTrack. */
+#define ROM_MUSIC_TABLE         0x08118AB4
+
+/* Music track metadata table (offsets, lengths, loop points).
+ * Paired with ROM_MUSIC_TABLE. */
+#define ROM_MUSIC_META_TABLE    0x08118AE4
+
+/* Sound command dispatch table.
+ * Array of function pointers indexed by command byte. */
+#define ROM_SOUND_CMD_TABLE     0x08117C8C
+
+/* Instrument/voice table.
+ * Contains waveform, envelope, and pitch data for each instrument. */
+#define ROM_INSTRUMENT_TABLE    0x081179E4
+
+/* Pitch/frequency lookup tables for MIDI note-to-frequency conversion. */
+#define ROM_FREQ_TABLE_1        0x08117A74
+#define ROM_FREQ_TABLE_2        0x08117B28
+#define ROM_PITCH_TABLE         0x08117B70
+#define ROM_WAVE_DUTY_TABLE     0x08117BF4
+#define ROM_NOISE_TABLE         0x08117C0C
+#define ROM_ENVELOPE_TABLE      0x08117C48
+#define ROM_SWEEP_TABLE         0x08117C58
+
+/* Sound configuration init data. */
+#define ROM_SOUND_INIT_DATA     0x081177E4
 
 #endif /* GUARD_GLOBALS_H */

--- a/src/m4a.c
+++ b/src/m4a.c
@@ -1,46 +1,70 @@
 #include "global.h"
+#include "gba.h"
 #include "globals.h"
 #include "include_asm.h"
 
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804eb64);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804ed68);
+/* ── Sound System Initialization & Shutdown ── */
+
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804eb64); /* SoundMain — main sound system setup, calls stream/gfx init */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804ed68); /* SoundDmaInit — DMA controller setup for sound transfers */
 /*
- * Frees a sound data structure and its inner buffer.
- * Reads the struct pointer from 0x0300081C, frees *(struct) - 4 (inner buffer
- * with header), then frees the struct pointer itself.
+ * Frees the sound info struct and its inner sample buffer.
+ * Reads gSoundInfo, frees the inner buffer (at offset -4),
+ * then frees the struct itself.
  *   no parameters
  *   no return value
  */
 void FreeSoundStruct(void) {
-    u32 *p = (u32 *)0x0300081C;
+    u32 *p = (u32 *)0x0300081C; /* &gSoundInfo */
     thunk_FUN_0800020c(*(u32 *)(*p) - 4);
     thunk_FUN_0800020c(*p);
 }
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804ee34);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804ee60);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804ef50);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804efde);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804f004);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804f0d0);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804f180);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804f1c4);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804f248);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804f6d4);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804f6f4);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804f724);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804f73c);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804f758);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804f766);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804f7b4);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804f944);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804fb9c);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804fbe0);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804fc10);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804fe50);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804fe6c);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804fea0);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804ff08); /* ResetSoundChannel */
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804ff44);
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804ee34); /* SoundReset — minimal state reset */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804ee60); /* DmaControllerInit — full DMA init with channel setup */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804ef50); /* SoundInfoInit — initialize SoundInfo struct fields */
+
+/* ── Sound Data & Buffer Management ── */
+
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804efde); /* SoundBufferAlloc — allocate sound mixing buffers */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804f004); /* SoundContextInit — setup sound context / mixer state */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804f0d0); /* SoundChannelTableInit — initialize channel table entries */
+
+/* ── MIDI / Music Sequence Processing ── */
+
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804f180); /* MidiReadUnaligned — read unaligned MIDI value */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804f1c4); /* MidiProcessEvent — dispatch MIDI note/control event */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804f248); /* MPlayMain — CORE: main music player tick (587 lines, DMA) */
+
+/* ── Voice / Instrument Utilities ── */
+
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804f6d4); /* VoiceUtil — minimal voice utility */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804f6f4); /* VoiceLookup — voice lookup wrapper */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804f724); /* InstrumentLookup — ROM instrument table lookup */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804f73c); /* InstrumentGetEntry — get instrument from ROM_INSTRUMENT_TABLE */
+
+/* ── Sound Channel Control ── */
+
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804f758); /* MidiDecodeByte — decode single MIDI byte */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804f766); /* MidiNoteSetup — setup MIDI note on channel */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804f7b4); /* MidiCommandHandler — MIDI command dispatch (writes SOUND1CNT) */
+
+/* ── Music Playback Engine ── */
+
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804f944); /* MPlayContinue — music playback continuation (327 lines) */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804fb9c); /* SoundContextRef — get sound context reference */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804fbe0); /* MPlayStop_Channel — stop single music channel */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804fc10); /* MPlayStop — stop all music playback (313 lines) */
+
+/* ── Sound Effect Processing ── */
+
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804fe50); /* SoundEffectUtil — sound effect utility */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804fe6c); /* SoundEffectProcess — process sound effect chain */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804fea0); /* FreqTableLookup — frequency lookup from ROM pitch tables */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804ff08); /* MPlayChannelReset — reset channel state (Sappy magic check) */
+
+/* ── Sound Init Dispatcher & Track Control ── */
+
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804ff44); /* m4aSoundInit_Impl — full sound system init dispatcher */
 /*
  * Wrapper that calls FUN_0804f294 to initialize the sound engine.
  *   no parameters
@@ -49,74 +73,97 @@ INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804ff44);
 void SoundInit(void) {
     FUN_0804f294();
 }
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804ffc8); /* PlayMusicTrack */
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804fff6);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050042);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050094); /* ExecuteMusicCommand */
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_080500c8);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_080500fc); /* UpdateAllSoundChannels */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804ffc8); /* m4aSongNumStart — start playing music track by ID */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0804fff6); /* m4aSongNumContinue — continue/queue music track */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050042); /* m4aSongNumLoad — load music data from ROM */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050094); /* m4aMPlayCommand — execute music player command */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_080500c8); /* m4aSongNumStop — stop current music track */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_080500fc); /* m4aSoundVSync — VBlank: update all sound channels (×4 loop) */
 /*
  * Wrapper that calls FUN_0804ff08 to stop/reset a sound channel.
- * Passes through r0 (sound struct pointer).
- *   r0: pointer to sound struct
+ *   r0: pointer to sound channel struct
  *   no return value
  */
 void StopSoundChannel(u32 r0) {
     FUN_0804ff08(r0);
 }
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050134); /* SetupSoundInterrupt */
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050162);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_080501ba);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050200);
+
+/* ── Interrupt & VBlank Handlers ── */
+
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050134); /* m4aSoundVSyncSetup — setup VBlank sound sync */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050162); /* SappyStateCheck — verify Sappy magic marker (0x68736D53) */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_080501ba); /* SoundEffectTrigger — trigger sound effect via gMPlayInfo_SE */
+
+/* ── Sound Hardware Initialization ── */
+
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050200); /* SoundHardwareInit — CRITICAL: init all GBA sound regs (14 HW regs) */
 /*
- * Calls FUN_0805186c with the given parameter and a global sound context
- * pointer from 0x030064D8 as the second argument.
- *   r0: first argument passed through to FUN_0805186c
+ * Calls FUN_0805186c (PlaySoundEffect) with the given parameter
+ * and the BGM music player context as the second argument.
+ *   r0: sound effect ID
  *   no return value
  */
 void PlaySoundWithContext_D8(u32 r0) {
-    FUN_0805186c(r0, gSoundCtx_D8);
+    FUN_0805186c(r0, gMPlayInfo_BGM);
 }
 /*
- * Calls FUN_0805186c with the given parameter and a global sound context
- * pointer from gSoundCtx_DC as the second argument.
- *   r0: first argument passed through to FUN_0805186c
+ * Calls FUN_0805186c (PlaySoundEffect) with the given parameter
+ * and the SE music player context as the second argument.
+ *   r0: sound effect ID
  *   no return value
  */
 void PlaySoundWithContext_DC(u32 r0) {
-    FUN_0805186c(r0, gSoundCtx_DC);
+    FUN_0805186c(r0, gMPlayInfo_SE);
 }
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050344);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0805043c);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_080504e0);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050578);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_080505cc); /* StopAllSound */
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050648); /* SetupVBlankSoundHandler */
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050684);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_080506fc); /* LoadSoundData */
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_080507e0); /* UpdateSoundChannel */
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050820);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_080508e8);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0805099e);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050a94);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050afc);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050c70);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050f4a);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050f70);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050fd8);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0805104c);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_080510b4);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_080510d4);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08051148);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_080511bc);
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08051314);
+
+/* ── Direct Sound & DMA Configuration ── */
+
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050344); /* DirectSoundFifoSetup — FIFO_A/B and DMA config (8 HW regs) */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0805043c); /* SoundTimerSetup — configure timer for sample rate */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_080504e0); /* SoundSystemConfigure — configure sound system mode */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050578); /* SoundPlatformDetect — detect platform/capabilities */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_080505cc); /* m4aSoundShutdown — emergency stop all sound */
+
+/* ── VBlank Sound Update Pipeline ── */
+
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050648); /* m4aSoundVSyncOn — register VBlank sound handler */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050684); /* VBlankSoundCallback — VBlank-triggered sound update */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_080506fc); /* MPlayOpen — load & open music player data from ROM */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_080507e0); /* MPlayChannelUpdate — update single music channel */
+
+/* ── Volume, Pitch & CGB Sound Control ── */
+
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050820); /* CgbModVol — CGB channel volume modulation */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_080508e8); /* CgbLookupTable — CGB frequency/volume lookup data */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0805099e); /* MidiKeyToCgbFreq — MIDI note → CGB frequency (4 pitch regs) */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050a94); /* CgbLookupUtil — CGB utility lookup */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050afc); /* CgbSound — CGB channel hardware control (14 HW regs) */
+
+/* ── Core Mixer / Channel Processing Loop ── */
+
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050c70); /* SoundMixerMain — CORE: process all mixer channels (393 lines) */
+
+/* ── State Machine & Sappy Verification ── */
+
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050f4a); /* SoundStateCheck1 — Sappy magic state check */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050f70); /* SoundStateCheck2 — Sappy magic state check */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08050fd8); /* SoundStateCheck3 — Sappy magic state check */
+
+/* ── MIDI Note & Command Encoding ── */
+
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_0805104c); /* MidiNoteLookup — MIDI note to frequency lookup */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_080510b4); /* MidiUtilConvert — MIDI utility converter */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_080510d4); /* MidiCommandEncode1 — encode MIDI command type 1 */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08051148); /* MidiCommandEncode2 — encode MIDI command type 2 */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_080511bc); /* MPlayCommandDispatch — music command dispatcher (ROM table) */
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08051314); /* SoundCommandHandler — command dispatch from ROM_SOUND_CMD_TABLE */
 /*
- * Calls FUN_08051870 with two pass-through arguments and a global
- * sound table pointer from 0x03006450 as the third argument.
- *   r0, r1: passed through to FUN_08051870
+ * Dispatches a sound command through FUN_08051870 (DispatchSoundCommand)
+ * using the global sound table pointer.
+ *   r0, r1: command arguments passed through
  *   no return value
  */
 void SoundCommand_6450(u32 r0, u32 r1) {
     FUN_08051870(r0, r1, gSoundTablePtr);
 }
-INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08051348);
+INCLUDE_ASM("asm/nonmatchings/m4a", FUN_08051348); /* BitMaskLUT — 32-bit channel bitmask lookup table */


### PR DESCRIPTION
## Summary

Name all 62 undecompiled functions in the m4a (MusicPlayer2000/Sappy) sound module with proposed semantic names, add GBA sound hardware register defines, and document 12 ROM sound data tables.

### New GBA sound registers in `include/gba.h`

- **Channels 1-4**: `REG_SOUND1CNT_L`/`H`/`X` through `REG_SOUND4CNT_L`/`H`
- **Wave RAM**: `REG_WAVE_RAM0`-`REG_WAVE_RAM3`
- **Direct Sound**: `REG_FIFO_A`, `REG_FIFO_B`

### New sound globals in `include/globals.h`

- Renamed `gSoundCtx_D8/DC` → `gMPlayInfo_BGM/SE` (standard m4a naming)
- Added: `gSoundCmdTablePtr`, `gSoundEventBuffer`, `SAPPY_MAGIC` (0x68736D53)
- 12 ROM data table constants for the sound engine

### Function naming (all 62 INCLUDE_ASM in m4a.c)

Following MusicPlayer2000/Sappy conventions used by pokeemerald and other GBA decomps:

**Core engine (3 largest functions)**:
| Lines | Proposed Name | Role |
|-------|---------------|------|
| 587 | `MPlayMain` | Main music player tick with DMA |
| 393 | `SoundMixerMain` | Process all mixer channels |
| 313 | `MPlayStop` | Stop all music playback |

**Hardware access tiers**:
| Tier | Function | HW Regs | Role |
|------|----------|---------|------|
| 1 | `SoundHardwareInit` | 14 regs | Master init: SOUNDCNT, FIFO, DMA |
| 2 | `DirectSoundFifoSetup` | 8 regs | FIFO_A/B and DMA config |
| 3 | `CgbSound` | 14 regs | Per-CGB-channel hardware writes |
| 4 | `MidiKeyToCgbFreq` | 4 regs | MIDI note → frequency conversion |

**Standard m4a API names**: `m4aSongNumStart`, `m4aSongNumStop`, `m4aSongNumContinue`, `m4aSoundVSync`, `m4aSoundVSyncOn`, `m4aSoundShutdown`

**ROM data tables** (12 new constants):
`ROM_MUSIC_TABLE`, `ROM_MUSIC_META_TABLE`, `ROM_SOUND_CMD_TABLE`, `ROM_INSTRUMENT_TABLE`, `ROM_FREQ_TABLE_1/2`, `ROM_PITCH_TABLE`, `ROM_WAVE_DUTY_TABLE`, `ROM_NOISE_TABLE`, `ROM_ENVELOPE_TABLE`, `ROM_SWEEP_TABLE`, `ROM_SOUND_INIT_DATA`

### Data flow

```
SoundInit()
  → InitSoundEngine (FUN_0804f294)
    → SoundHardwareInit → writes SOUNDCNT_L/H/X, FIFO_A/B, DMA

m4aSongNumStart(trackId)
  → MPlayOpen → loads from ROM_MUSIC_TABLE
    → MPlayMain → DMA-driven MIDI processing
      → MidiCommandHandler → instrument/note dispatch
        → CgbSound → channel hardware writes

m4aSoundVSync() [VBlank]
  → MPlayChannelUpdate (×4 channels)
    → SoundMixerMain → core mixing loop
```

## Test plan

- [x] `make compare` passes (byte-exact SHA1 match)
- [x] Comments only — no functional code changes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)