### PR TITLE
Decompile FUN_080009a8 as real C (replaces PR #31's naked asm)

### DIFF
--- a/src/math.c
+++ b/src/math.c
@@ -10,7 +10,16 @@ s16 FUN_08000978(s16 arg0) {
     return FUN_080518a4(0x10000, arg0);
 }
 INCLUDE_ASM("asm/nonmatchings/math", FUN_08000992);
-INCLUDE_ASM("asm/nonmatchings/math", FUN_080009a8);
+/*
+ * FixedPointMul4: fixed-point multiply with 4-bit left shift on first arg.
+ * Computes FUN_080518a4(arg0 << 4, arg1) and sign-extends the result to s16.
+ *   arg0: s16 multiplicand (shifted left 4 = x16 scaling)
+ *   arg1: s16 multiplier
+ *   returns: s16 result
+ */
+s16 FUN_080009a8(s16 arg0, s16 arg1) {
+    return FUN_080518a4((s32)arg0 << 4, arg1);
+}
 s16 FUN_080009c2(s16 arg0) {
     return FUN_080518a4(0x100, arg0);
 }


### PR DESCRIPTION
## Summary

Decompile FUN_080009a8 (math.c) as a one-line C wrapper, replacing the `__attribute__((naked))` + inline assembly approach in PR #31.

### The function

```c
s16 FUN_080009a8(s16 arg0, s16 arg1) {
    return FUN_080518a4((s32)arg0 << 4, arg1);
}
```

This is a fixed-point scaled multiply that shifts the first argument left by 4 bits (×16 scaling) before passing to FUN_080518a4.

### Why this is better than PR #31

PR #31 used `naked` + inline asm which is just the assembly wrapped in a C function — not a real decompilation. This PR shows the actual C logic that compiles to byte-identical output, including the `pop {r1}; bx r1` epilogue (which agbcc generates correctly for these math wrappers).

### Related

- Closes #8 (FUN_080009a8 shared epilogue — now resolved, it matches as real C)
- FUN_08000978 already matched in a similar way (merged in earlier PR)
- FUN_08000992 (PR #30) remains blocked: it's `non_word_aligned` so it genuinely can't be compiled from C

## Test plan

- [x] `make compare` passes (byte-exact SHA1 match)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)