### PR TITLE
Decompile 11 functions across 5 modules

### DIFF
--- a/src/m4a.c
+++ b/src/m4a.c
@@ -139,7 +139,28 @@ INCLUDE_ASM("asm/nonmatchings/m4a", StreamCmd_SetChannelMode);
  * reads u16 from stream bytes[4-5] -> gSoundInfo[0x12].
  * Advances stream by 6.
  */
-INCLUDE_ASM("asm/nonmatchings/m4a", StreamCmd_SetSoundFreqs);
+u32 ReadUnalignedU16(u8 *);
+void StreamCmd_SetSoundFreqs(void)
+{
+    u32 a0 = 0x03004D84;
+    u8 **streamRef;
+    u16 val;
+    asm("" : "=r"(streamRef) : "0"(a0));
+
+    val = ReadUnalignedU16(*streamRef + 2);
+
+    {
+        u32 a1 = 0x0300081C;
+        u16 **infoRef;
+        asm("" : "=r"(infoRef) : "0"(a1));
+        (*infoRef)[0x10 / 2] = val;
+
+        val = ReadUnalignedU16(*streamRef + 4);
+        (*infoRef)[0x12 / 2] = val;
+    }
+
+    *streamRef += 6;
+}
 INCLUDE_ASM("asm/nonmatchings/m4a", StreamCmd_AdvanceStream);
 /*
  * MidiProcessEvent: dispatch a MIDI note or control event.


### PR DESCRIPTION
## Summary

11 new matching C implementations, bringing the total to 50 matched functions.

**code_1.c:**
- **TransitionToWorldMap** — world map transition with callback state setup

**code_3.c:**
- **GetEntityLookupData** — entity table lookup (shift-pair interleaving)

**system.c:**
- **FixedMul8** — 8.8 fixed-point signed multiply with rounding

**m4a.c (6 functions):**
- **InitSceneState** — sound scene init via voice table lookup
- **m4aSongNumStop** — stop song if currently playing
- **m4aMPlayCommand** — stop player for matching song
- **SoundCmd_Dispatch** — command byte dispatch from channel stream
- **StreamCmd_StopSoundAndSync** — stop sound + sync freq to BG scroll
- **StreamCmd_SetSoundFreqs** — read two u16 frequencies from stream

**gfx.c:**
- **SetupGfxCallbacks** — world map VBlank/callback initialization
- **FadeOutController** — screen fade-out with scene transition switch

## Techniques used

- `asm("" : "+r"(val))` barrier to force memory loads before constant loads
- `register type var asm("rN")` + barrier to force dead copies (FixedMul8)
- Integer arithmetic (`offset += (u32)base`) to control `adds` operand order
- Shift-pair interleaving for table lookups (m4a voice table pattern)
- Callee-saved pointer reuse across function calls (StreamCmd_StopSoundAndSync)

## Test plan

- [x] `make compare` passes (byte-exact SHA1 match)
- [x] Each function verified individually before commit

## Note

Supersedes #49 (which had the first 8 of these 11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)