### PR TITLE
Decompile SoundChannelResetAll

### DIFF
--- a/src/m4a.c
+++ b/src/m4a.c
@@ -559,7 +559,49 @@ INCLUDE_ASM("asm/nonmatchings/m4a", SoundSystemConfigure);
  * then calls FUN_0805186c for channels 1-4 with the voice table.
  * Restores SAPPY_MAGIC on exit.
  */
-INCLUDE_ASM("asm/nonmatchings/m4a", SoundChannelResetAll);
+void SoundChannelResetAll(void) {
+    u32 a0 = 0x03007FF0;
+    u32 **infoRef;
+    u32 *info;
+    u32 magic;
+    s32 counter;
+    u8 *ptr;
+
+    asm("" : "=r"(infoRef) : "0"(a0));
+    info = *infoRef;
+    magic = info[0];
+
+    {
+        u32 a1 = SAPPY_MAGIC;
+        u32 expected;
+        asm("" : "=r"(expected) : "0"(a1));
+        if (magic != expected)
+            return;
+    }
+
+    info[0] = magic + 1;
+
+    counter = 12;
+    ptr = (u8 *)info + 0x50;
+    do {
+        *ptr = 0;
+        counter--;
+        ptr += 0x40;
+    } while (counter > 0);
+
+    ptr = (u8 *)info[0x1C / 4];
+    if (ptr != NULL) {
+        counter = 1;
+        do {
+            FUN_0805186c((u8)counter, info[0x2C / 4]);
+            *ptr = 0;
+            counter++;
+            ptr += 0x40;
+        } while (counter <= 4);
+    }
+
+    info[0] = SAPPY_MAGIC;
+}
 /*
  * m4aSoundShutdown: emergency stop — shut down all sound output.
  * Silences all channels, stops DMA, and resets hardware registers.


### PR DESCRIPTION
## Summary

- **SoundChannelResetAll** (m4a) — resets all 12 channel status bytes at stride 0x40, then calls FUN_0805186c for channels 1-4 with the voice table. Checks and restores SAPPY_MAGIC.

New technique: **function-scoped variable reuse** — declaring `counter` and `ptr` at function scope (rather than in separate block scopes) forces the compiler to reuse callee-saved registers (r4/r5) across both loops, matching the original's register allocation.

Total matched: **53 functions**.

## Test plan

- [x] `make compare` passes
- [x] `make check_format` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)