### PR TITLE
Patch agbcc with -ftst, decompile VoiceLookupAndApply

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ DATA_BUILDDIR := $(OBJ_DIR)/$(DATA_SUBDIR)
 ASM_SRCS := $(wildcard $(ASM_SUBDIR)/*.s)
 ASM_OBJS := $(patsubst $(ASM_SUBDIR)/%.s,$(ASM_BUILDDIR)/%.o,$(ASM_SRCS))
 
-C_SRCS := $(wildcard $(C_SUBDIR)/*.c)
+C_SRCS := $(filter-out $(C_SUBDIR)/m4a_1.c,$(wildcard $(C_SUBDIR)/*.c))
 C_OBJS := $(patsubst $(C_SUBDIR)/%.c,$(C_BUILDDIR)/%.o,$(C_SRCS))
 
 DATA_SRCS := $(wildcard $(DATA_SUBDIR)/*.s)
@@ -61,6 +61,11 @@ OBJS_REL := $(patsubst $(OBJ_DIR)/%,%,$(OBJS))
 ASFLAGS  := -mcpu=arm7tdmi -mthumb-interwork
 CPPFLAGS := -nostdinc -I tools/agbcc/include -iquote include
 CC1FLAGS := -mthumb-interwork -Wimplicit -Wparentheses -O2 -fhex-asm -fprologue-bugfix
+
+# TST compilation unit: m4a_1.c is pre-compiled with -ftst into build/m4a_1_funcs.s,
+# then included as assembly in m4a.c via asm(".include ..."). This keeps all m4a
+# functions in one .text section (required by shared literal pools in the ROM assembly).
+TST_CC1FLAGS := $(CC1FLAGS) -ftst
 
 DECOMP_TOML := klonoa-eod-decomp.toml
 LDSCRIPT    := ldscript.txt
@@ -108,6 +113,15 @@ $(LDSCRIPT): $(LDSCRIPT_IN) $(DECOMP_TOML)
 $(ASM_BUILDDIR)/%.o: $(ASM_SUBDIR)/%.s
 	@echo "$(AS) <flags> -o $@ $<"
 	@$(AS) $(ASFLAGS) -o $@ $<
+
+# Pre-compile TST functions (m4a_1.c → build/m4a_1_funcs.s)
+$(OBJ_DIR)/m4a_1_funcs.s: $(C_SUBDIR)/m4a_1.c
+	@echo "$(CC1) <flags> -ftst -o $@ $<"
+	@$(CPP) $(CPPFLAGS) $< -o $(OBJ_DIR)/m4a_1.i
+	@$(CC1) $(TST_CC1FLAGS) -o $(OBJ_DIR)/m4a_1_raw.s $(OBJ_DIR)/m4a_1.i
+	@sed '/^@/d;/^\.code/d;/^\.gcc2_compiled/d;/^\.text$$/d;/^\.Lfe/d;/^[[:space:]]*\.size/d;/macros\.inc/d;s/\.L\([0-9]\)/.Lm4a1_\1/g' $(OBJ_DIR)/m4a_1_raw.s > $@
+
+$(C_BUILDDIR)/m4a.o: $(OBJ_DIR)/m4a_1_funcs.s
 
 # Compile C files (with INCLUDE_ASM support)
 $(C_BUILDDIR)/%.o: $(C_SUBDIR)/%.c

--- a/src/m4a.c
+++ b/src/m4a.c
@@ -185,10 +185,15 @@ INCLUDE_ASM("asm/nonmatchings/m4a", MPlayTrackCallback);
  */
 INCLUDE_ASM("asm/nonmatchings/m4a", VoiceGetParams);
 /*
- * VoiceLookup: voice parameter lookup wrapper.
+ * VoiceLookupAndApply: walk linked list of active voices and apply parameters.
+ *
+ * C source is in src/m4a_1.c (TST compilation unit, compiled with -ftst).
+ * The build system pre-compiles m4a_1.c into build/m4a_1_funcs.s, which is
+ * included here as assembly so it stays in the same .text section as the
+ * other m4a functions (required due to shared literal pools). See issue #54.
  *   28 lines, calls VoiceGetParams
  */
-INCLUDE_ASM("asm/nonmatchings/m4a", VoiceLookupAndApply);
+asm(".include \"build/m4a_1_funcs.s\"");
 /*
  * InstrumentLookup: look up instrument data from ROM_INSTRUMENT_TABLE.
  * Given a program/voice number, returns a pointer to the instrument entry

--- a/src/m4a_1.c
+++ b/src/m4a_1.c
@@ -1,0 +1,46 @@
+#include "global.h"
+#include "gba.h"
+#include "globals.h"
+#include "include_asm.h"
+
+/* ══════════════════════════════════════════════════════════════════════
+ * m4a_1 — TST compilation unit of the MusicPlayer2000 sound engine
+ *
+ * These functions were compiled with a TST-capable compiler revision in
+ * the original ROM. They use the tst instruction for bitwise flag tests
+ * instead of the ands+cmp sequence used by the rest of m4a.
+ *
+ * This file is compiled with -ftst to match the original code generation.
+ * Only decompiled C functions go here; INCLUDE_ASM functions stay in m4a.c
+ * since they produce raw assembly unaffected by compiler flags.
+ * See GitHub issue #54 for details.
+ * ══════════════════════════════════════════════════════════════════════ */
+
+void VoiceGetParams(u32 *);
+
+/**
+ * VoiceLookupAndApply: walk linked list of active voices and apply parameters.
+ *
+ * Iterates through the voice chain starting at info[0x20/4]. For each voice,
+ * if any status bits in 0xC7 are set (active/keyon/sustain/release), marks
+ * the voice as requiring update (sets bit 0x40). Then calls VoiceGetParams
+ * to apply the voice's current parameters. Finally clears the caller's
+ * status byte.
+ *
+ * @param unused   Unused first parameter (register r0 not referenced)
+ * @param info     Pointer to sound channel/track structure
+ */
+void VoiceLookupAndApply(u32 unused, u32 *info) {
+    u32 *node = (u32 *)info[0x20 / 4];
+
+    while (node != NULL) {
+        u8 status = *(u8 *)node;
+        if (status & 0xC7) {
+            *(u8 *)node = status | 0x40;
+        }
+        VoiceGetParams(node);
+        node = (u32 *)node[0x34 / 4];
+    }
+
+    *(u8 *)info = 0;
+}


### PR DESCRIPTION
## Summary

- Patch agbcc compiler with `-ftst` flag for Thumb TST instruction support
- Split m4a into separate compilation units (TST vs non-TST)
- Decompile VoiceLookupAndApply (byte-exact match)

## agbcc compiler patches

Two new patterns in `tools/agbcc/gcc/thumb.md`, gated behind `-ftst`:

| Pattern | When | Emits | Replaces |
|---------|------|-------|----------|
| `*andsi3_tst` | AND result dead, only flags needed | `tst Rn, Rm` | `and Rd, Rm; cmp Rd, #0` |
| `*andsi3_setflags` | AND result live AND flags needed | `and Rd, Rm` (no cmp) | `and Rd, Rm; cmp Rd, #0` |

Flag mechanism follows `-fprologue-bugfix` precedent (flag in `flags.h`, registered in `toplev.c`).

## Why per-compilation-unit?

Analysis of all 36 `tst` instructions in the ROM:
- **No function mixes `tst` and `ands+cmp`** — always one or the other
- 7 functions use TST exclusively (core MP2000 engine)
- ~50 functions use `ands+cmp` exclusively
- The TST and non-TST functions are interleaved in ROM order

This means the original m4a library was compiled from multiple source files with different compiler revisions. `-ftst` cannot be applied globally without breaking already-matched functions.

## Build system: pre-compiled inclusion

```
src/m4a_1.c ──(agbcc -ftst)──> build/m4a_1_funcs.s ──(asm .include)──> src/m4a.c ──> m4a.o
```

m4a_1.c is pre-compiled with `-ftst`, then its assembly output is included in m4a.c via inline asm. This keeps all m4a functions in one `.text` section (required by shared literal pools in the ROM assembly).

## Test plan

- [x] `make compare` passes (SHA1 match)
- [x] `make format` clean
- [x] VoiceLookupAndApply byte-exact match verified
- [x] m4aSoundVSyncOff still matches (non-TST compilation unit)

Refs: #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)