### PR TITLE
Revert -ftst -fcmp-elim from m4a.c compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ $(OBJ_DIR)/m4a_1_funcs.s: $(C_SUBDIR)/m4a_1.c
 $(C_BUILDDIR)/m4a.o: $(C_SUBDIR)/m4a.c $(OBJ_DIR)/m4a_1_funcs.s
 	@echo "$(CC1_OLD) <m4a flags> -o $@ $<"
 	@$(CPP) $(CPPFLAGS) $< -o $(C_BUILDDIR)/m4a.i
-	@$(CC1_OLD) -mthumb-interwork -O2 -ftst -fcmp-elim -o $(C_BUILDDIR)/m4a.s $(C_BUILDDIR)/m4a.i
+	@$(CC1_OLD) -mthumb-interwork -O2 -o $(C_BUILDDIR)/m4a.s $(C_BUILDDIR)/m4a.i
 	@printf ".text\n\t.align\t2, 0\n" >> $(C_BUILDDIR)/m4a.s
 	@$(AS) $(ASFLAGS) -o $@ $(C_BUILDDIR)/m4a.s
 

--- a/src/m4a.c
+++ b/src/m4a.c
@@ -281,47 +281,13 @@ INCLUDE_ASM("asm/nonmatchings/m4a", MPlayContinue);
  * Iterates the linked list of sound channels starting at track[0x20].
  * For each channel with a nonzero status byte, checks if the type
  * field (byte offset 1) has any of the low 3 bits set. If so, calls
- * SoundChannelRelease via the soundInfo callback table. Clears each
- * channel's status byte and callback pointer (offset 0x2C), then NULLs
- * the track's channel list head.
- *
- * @param unused   Unused (register r0, not referenced)
- * @param track    Pointer to the MusicPlayerTrack structure
+ * SoundChannelRelease. Clears each channel's status byte and callback
+ * pointer (offset 0x2C), then NULLs the track's channel list head.
+ *   39 lines, calls SoundChannelRelease
+ *   Needs -ftst for tst r0,r1 pattern but -ftst breaks other m4a functions.
+ *   Reverted to INCLUDE_ASM until per-function flag support is added.
  */
-void SoundContextRef(u32 unused, u8 *track) {
-    u8 *chan;
-    u8 zero;
-    register u8 st asm("r1") = track[0];
-    register u32 m asm("r0") = 0x80;
-    st &= m;
-    if (!st)
-        goto end;
-    chan = *(u8 **)(track + 0x20);
-    if (!chan)
-        goto store_null;
-    zero = 0;
-    do {
-        if (chan[0]) {
-            register u32 type asm("r0") = chan[1];
-            register u32 mask asm("r3") = 7;
-            type &= mask;
-            if (type) {
-                u32 addr = 0x03007FF0;
-                asm("" : "=r"(mask) : "0"(addr));
-                mask = *(volatile u32 *)mask;
-                mask = *(volatile u32 *)(mask + 0x2C);
-                SoundChannelRelease();
-            }
-            asm("" : : "r"(type));
-            chan[0] = zero;
-        }
-        *(u32 *)(chan + 0x2C) = zero;
-        chan = *(u8 **)(chan + 0x34);
-    } while (chan);
-store_null:
-    *(u8 **)(track + 0x20) = chan;
-end:;
-}
+INCLUDE_ASM("asm/nonmatchings/m4a", SoundContextRef);
 /*
  * MPlayStop_Channel: stop playback on a single music channel.
  * Silences one channel without affecting other active tracks.


### PR DESCRIPTION
## Summary

Removes `-ftst -fcmp-elim` flags from m4a.c compilation and reverts SoundContextRef to INCLUDE_ASM.

PR #69 added these flags which converted 6 `ands+cmp` patterns to `tst` in matched m4a functions, making m4a.o 12 bytes shorter than the original ROM. The original ROM uses `ands+cmp` for most m4a functions but `tst` for a few (like SoundContextRef), so global `-ftst` is incorrect.

This restores the pre-existing 12-byte-too-large mismatch (separate issue from generate_asm.py padding).

Refs #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)